### PR TITLE
Ensure throttle callbacks are always called

### DIFF
--- a/lib/allowed/limit.rb
+++ b/lib/allowed/limit.rb
@@ -18,6 +18,7 @@ module Allowed
         validate :validate_throttles, on: :create
 
         after_rollback :handle_throttles, on: :create
+        after_validation :handle_throttles, on: :create
       end
     end
 

--- a/spec/lib/allowed/limit_spec.rb
+++ b/spec/lib/allowed/limit_spec.rb
@@ -36,6 +36,7 @@ describe Allowed::Limit, "#allow" do
   it "only calls validation callback on create" do
     instance = subject.new
     instance.stubs(:validate_throttles)
+    instance.stubs(:handle_throttles)
 
     instance.save
     instance.save
@@ -47,6 +48,12 @@ describe Allowed::Limit, "#allow" do
     subject.allow(limit, options)
 
     expect(subject).to have_callback(:rollback, :handle_throttles, kind: :after, on: :create)
+  end
+
+  it "adds after validation callback" do
+    subject.allow(limit, options)
+
+    expect(subject).to have_callback(:validation, :handle_throttles, kind: :after, on: :create)
   end
 end
 


### PR DESCRIPTION
This corrects an edge case we discovered in which records created with `find_or_create_by` which failed this validation did not call the failure callbacks. Adding `handle_throttles` to trigger on `after_validation` returns to the logic we had in place before this code was extracted out of our core app and into a gem.
