### PR TITLE
Allow dynamic limit with an instance method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,9 @@ class Comment < ActiveRecord::Base
   allow 100, per: 7.days, unless: :whitelisted_user?
   allow 100, per: 7.days, unless: -> (comment) { comment.user.admin? }
 
+  # Dynamic limit.
+  allow :user_daily_limit, per: 1.day
+
   # Callbacks when limit is reached.
   allow 10, per: 2.minutes, callback: -> (comment) { comment.user.suspend! }
   allow 25, per: 5.minutes do |comment|
@@ -28,6 +31,10 @@ class Comment < ActiveRecord::Base
 
   def whitelisted_user?
     user.whitelisted? || screenshot.user == user
+  end
+
+  def user_daily_limit
+    user.daily_limit
   end
 end
 ```

--- a/lib/allowed/throttle.rb
+++ b/lib/allowed/throttle.rb
@@ -18,7 +18,7 @@ module Allowed
     def valid?(record)
       return true if skip?(record)
 
-      scope_for(record).count < limit
+      scope_for(record).count < allowed_count(record)
     end
 
     private
@@ -43,6 +43,15 @@ module Allowed
 
     def timeframe
       options.fetch(:per, 1.day).ago
+    end
+
+    def allowed_count(record)
+      case limit
+      when Integer
+        limit
+      when Symbol
+        record.__send__(limit)
+      end
     end
   end
 end

--- a/spec/lib/allowed/throttle_spec.rb
+++ b/spec/lib/allowed/throttle_spec.rb
@@ -102,6 +102,36 @@ describe Allowed::Throttle, "#valid?, above limit" do
   end
 end
 
+describe Allowed::Throttle, "#valid?, with limit method symbol" do
+  subject { Allowed::Throttle.new(:custom_limit) }
+
+  let(:record) { ExampleRecord.new }
+
+  before do
+    2.times { ExampleRecord.create }
+  end
+
+  it "returns true if higher than the count" do
+    ExampleRecord.class_eval do
+      def custom_limit
+        3
+      end
+    end
+
+    expect(subject).to be_valid(record)
+  end
+
+  it "returns false if lower than the count" do
+    ExampleRecord.class_eval do
+      def custom_limit
+        1
+      end
+    end
+
+    expect(subject).to_not be_valid(record)
+  end
+end
+
 describe Allowed::Throttle, "#valid?, with custom timeframe" do
   subject { Allowed::Throttle.new(1, per: 5.minutes) }
 


### PR DESCRIPTION
This enables different limits based on various factors (membership level, user's role within the app, phase of the moon, the possibilities are endless). It also makes testing easier by facilitating stubbing of the limit within a test run.
