### PR TITLE
Switch back to only after_rollback

### DIFF
--- a/lib/allowed/limit.rb
+++ b/lib/allowed/limit.rb
@@ -18,7 +18,6 @@ module Allowed
         validate :validate_throttles, on: :create
 
         after_rollback :handle_throttles, on: :create
-        after_validation :handle_throttles, on: :create
       end
     end
 

--- a/spec/lib/allowed/limit_spec.rb
+++ b/spec/lib/allowed/limit_spec.rb
@@ -49,12 +49,6 @@ describe Allowed::Limit, "#allow" do
 
     expect(subject).to have_callback(:rollback, :handle_throttles, kind: :after, on: :create)
   end
-
-  it "adds after validation callback" do
-    subject.allow(limit, options)
-
-    expect(subject).to have_callback(:validation, :handle_throttles, kind: :after, on: :create)
-  end
 end
 
 describe Allowed::Limit, "#handle_throttles" do


### PR DESCRIPTION
If new records are created in failure callback during after_validation, they will be lost when the transaction rolls back.

Undoes the change in https://github.com/dribbble/allowed/pull/2.
