### PR TITLE
Support a custom timeframe column.

### DIFF
--- a/lib/allowed/throttle.rb
+++ b/lib/allowed/throttle.rb
@@ -11,6 +11,10 @@ module Allowed
       options.fetch(:callback, -> (record) { })
     end
 
+    def timeframe_column
+      options.fetch(:timeframe_column, :created_at)
+    end
+
     def message
       options.fetch(:message, "Limit reached.")
     end
@@ -24,7 +28,7 @@ module Allowed
     private
 
     def scope_for(record)
-      scope      = record.class.where("created_at >= ?", timeframe)
+      scope      = record.class.where("#{timeframe_column} >= ?", timeframe)
       attributes = Array(options.fetch(:scope, []))
       attributes.inject(scope) do |scope, attribute|
         scope.where(attribute => record.__send__(attribute))

--- a/spec/lib/allowed/throttle_spec.rb
+++ b/spec/lib/allowed/throttle_spec.rb
@@ -15,6 +15,21 @@ describe Allowed::Throttle, ".new" do
   end
 end
 
+describe Allowed::Throttle, "#timeframe_column" do
+  it "returns timeframe_column if provided" do
+    column   = :updated_at
+    throttle = Allowed::Throttle.new(1, timeframe_column: column)
+
+    expect(throttle.timeframe_column).to eq(column)
+  end
+
+  it "returns created_at if not provided" do
+    throttle = Allowed::Throttle.new(1)
+
+    expect(throttle.timeframe_column).to eq(:created_at)
+  end
+end
+
 describe Allowed::Throttle, "#message" do
   it "returns message if provided" do
     message  = "The message."
@@ -155,5 +170,17 @@ describe Allowed::Throttle, "#valid?, with custom scope attributes" do
   it "uses scope attributes for count" do
     expect(subject).to be_valid(ExampleRecord.new(user_id: 1))
     expect(subject).to_not be_valid(ExampleRecord.new(user_id: 2))
+  end
+end
+
+describe Allowed::Throttle, "#valid?, with custom timeframe column" do
+  subject { Allowed::Throttle.new(1, timeframe_column: :updated_at) }
+
+  before do
+    ExampleRecord.create(created_at: 7.days.ago)
+  end
+
+  it "uses custom timeframe column" do
+    expect(subject).to_not be_valid(ExampleRecord.new)
   end
 end


### PR DESCRIPTION
Allows you to throttle records without a `created_at` column, or using a specific timeframe column.
- [ ] Better name for `timeframe_column`?
