### PR TITLE
Add a method for checking if throttles are valid.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,14 +1,18 @@
 # Changelog
 
-## 0.2.1 - September 19th, 2014
+## 0.3.0 — Unreleased
+
+* Add a method for checking if throttles are valid.
+
+## 0.2.1 — September 19th, 2014
 
 * Undo the change in 0.1.4; only trigger callbacks in `after_rollback` to avoid losing changes in the rollback which occurs afterward.
 
-## 0.2.0 - September 11th, 2014
+## 0.2.0 — September 11th, 2014
 
 * Provide a symbol as the limit to call a method on the record being saved.
 
-## 0.1.4 - September 11th, 2014
+## 0.1.4 — September 11th, 2014
 
 * Ensure failure callbacks trigger even if rollback is not triggered.
 

--- a/lib/allowed/limit.rb
+++ b/lib/allowed/limit.rb
@@ -21,6 +21,12 @@ module Allowed
       end
     end
 
+    def allowed?
+      self.class._throttles.all? do |throttle|
+        throttle.valid?(self)
+      end
+    end
+
     def handle_throttles
       @_throttle_failures.each do |throttle|
         throttle.callback.call(self)

--- a/spec/lib/allowed/limit_spec.rb
+++ b/spec/lib/allowed/limit_spec.rb
@@ -52,6 +52,25 @@ describe Allowed::Limit, "#allow" do
   end
 end
 
+describe Allowed::Limit, "#allowed?" do
+  subject { ExampleRecord.new }
+
+  let(:valid_throttle)   { double("throttle", valid?: true) }
+  let(:invalid_throttle) { double("throttle", valid?: false) }
+
+  it "returns true if all throttles valid" do
+    subject.class._throttles = [valid_throttle]
+
+    expect(subject).to be_allowed
+  end
+
+  it "returns false if any throttle invalid" do
+    subject.class._throttles = [valid_throttle, invalid_throttle]
+
+    expect(subject).to_not be_allowed
+  end
+end
+
 describe Allowed::Limit, "#handle_throttles" do
   subject { ExampleRecord.new }
 


### PR DESCRIPTION
Allows us to check the throttles before attempting creation.

- [x] Ideas for a better name? Maybe `throttles_allowed?` or `throttles_valid?`? I like `allowed?` but seems like it could overlap an existing method and isn't quite clear what it's allowing or not.