### PR TITLE
Add assertion around rollback callback happening

### DIFF
--- a/lib/allowed/limit.rb
+++ b/lib/allowed/limit.rb
@@ -17,7 +17,8 @@ module Allowed
 
         validate :validate_throttles, on: :create
 
-        after_rollback :handle_throttles, on: :create
+        # should be after_rollback, but Rails 5.2+ don't fire after_rollback or after_commit on failed creates
+        after_validation :handle_throttles, on: :create
       end
     end
 

--- a/spec/lib/allowed/limit_spec.rb
+++ b/spec/lib/allowed/limit_spec.rb
@@ -51,19 +51,28 @@ describe Allowed::Limit, "#allow" do
   end
 
   it "calls rollback callback on validation failure" do
-    instance = subject.new(user_id: -1)
+    subject.allow :max_count, callback: -> (record) { record.callback_triggered = true }
+
+    limit = 1
+    limit.times { subject.create! }
+    instance = subject.new(max_count: limit)
 
     expect(instance).to receive(:handle_throttles)
     expect(instance.valid?).to be_falsey
     expect(instance.save).to be_falsey
+    expect(instance.callback_triggered).to be true
   end
 
   it "does not call rollback callback on validation success" do
-    instance = subject.new
+    subject.allow :max_count, callback: -> (record) { record.callback_triggered = true }
+
+    limit = 1
+    instance = subject.new(max_count: limit)
 
     expect(instance).to_not receive(:handle_throttles)
     expect(instance.valid?).to be_truthy
     expect(instance.save).to be_truthy
+    expect(instance.callback_triggered).to be_nil
   end
 end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,7 +1,12 @@
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "spec/test.db")
 
 class ExampleRecord < ActiveRecord::Base
-  validates :user_id, numericality: {greater_than: 0, allow_blank: true}
+  attr_accessor :max_count
+  attr_accessor :callback_triggered
+
+  def max_count
+    @max_count || Float::INFINITY
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,6 +1,7 @@
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "spec/test.db")
 
 class ExampleRecord < ActiveRecord::Base
+  validates :user_id, numericality: {greater_than: 0, allow_blank: true}
 end
 
 RSpec.configure do |config|

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,5 +1,8 @@
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "spec/test.db")
 
+class Alert < ActiveRecord::Base
+end
+
 class ExampleRecord < ActiveRecord::Base
   attr_accessor :max_count
   attr_accessor :callback_triggered
@@ -9,14 +12,39 @@ class ExampleRecord < ActiveRecord::Base
   end
 end
 
+class Account < ActiveRecord::Base
+  has_many :widgets
+end
+
+class Widget < ActiveRecord::Base
+  belongs_to :account
+end
+
 RSpec.configure do |config|
   config.around do |example|
-    ExampleRecord._throttles = []
+    ActiveRecord::Base.direct_descendants.each do |klass|
+      klass._throttles = []
+    end
 
     ActiveRecord::Base.transaction do
       ActiveRecord::Migration.verbose = false
       ActiveRecord::Migration.create_table(:example_records) do |table|
         table.integer :user_id
+        table.timestamps
+      end
+
+      ActiveRecord::Migration.create_table(:alerts) do |table|
+        table.text :message
+        table.timestamps
+      end
+
+      ActiveRecord::Migration.create_table(:accounts) do |table|
+        table.timestamp :flagged_at
+        table.timestamps
+      end
+
+      ActiveRecord::Migration.create_table(:widgets) do |table|
+        table.references :account
         table.timestamps
       end
 


### PR DESCRIPTION
https://github.com/rails/rails/issues/36965 outlines a bug in Rails 5.2.x and higher that causes new records which fail validation to *not* call `after_rollback` callbacks, which this gem depends on for handling records failing a throttle. This PR adds tests that not only is the callback registered, but that it is fired in an attempt to suss out which versions are impacted and how best to address.
